### PR TITLE
fix for latest version of cli

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -35,7 +35,7 @@ var CmdSync = cli.Command{
 	Usage:  "keep syncing two end points",
 	Action: runSync,
 	Flags: []cli.Flag{
-		cli.StringFlag{"mode, m", "", "run mode", ""},
+		cli.StringFlag{Name: "mode, m", Value: "", Usage: "run mode"},
 	},
 }
 


### PR DESCRIPTION
When building with the latest version of `cli` this happens:

```
$ go get github.com/Unknwon/bra
# github.com/Unknwon/bra/cmd
../../Unknwon/bra/cmd/sync.go:38: cannot use "" (type string) as type *string in field value
```
