### PR TITLE
fix fsnotify import path

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,7 +29,7 @@ import (
 	"github.com/Unknwon/com"
 	"github.com/Unknwon/log"
 	"github.com/urfave/cli"
-	"gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify/fsnotify.v1"
 
 	"github.com/Unknwon/bra/modules/setting"
 )

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Unknwon/com"
 	"github.com/Unknwon/log"
 	"github.com/urfave/cli"
-	"gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify/fsnotify.v1"
 
 	"github.com/Unknwon/bra/modules/setting"
 )


### PR DESCRIPTION
https://github.com/go-fsnotify/fsnotify moved to https://github.com/fsnotify/fsnotify and no longer available via gopkg.in/fsnotify.v1