### PR TITLE
[RFC] Fix file not found error on Windows

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -241,7 +241,7 @@ func runRun(ctx *cli.Context) error {
 					showName = strings.Replace(showName, setting.WorkDir, "\033[47;30m$WORKDIR\033[0m", 1)
 				}
 
-				if e.Op&fsnotify.Remove != fsnotify.Remove {
+				if e.Op&fsnotify.Remove != fsnotify.Remove && e.Op&fsnotify.Rename != fsnotify.Rename {
 					mt, err := com.FileMTime(e.Name)
 					if err != nil {
 						log.Error("Fail to get file modify time: %v", err)


### PR DESCRIPTION
When using Intellij IDEA to edit a project, Windows users see a file not found error on L247. I believe this is due to how Intellij saves files (through renames instead of direct writes). So when bra tries to get the modified time for the file the file isn't there any more.

I tested this change on Windows and on Linux and everything seemed fine. The RFC is calling for others to test this change locally.