### PR TITLE
Make env files export compatible

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -124,7 +124,13 @@ func envFromFiles() []string {
 			continue
 		}
 
-		envs = append(envs, strings.Split(string(b), "\n")...)
+		envLines := strings.Split(string(b), "\n")
+		for _, env := range envLines {
+			if strings.HasPrefix(env, "export ") {
+				env = strings.Split(env, "export ")[1]
+			}
+			envs = append(envs, env)
+		}
 	}
 
 	return envs

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -126,10 +126,7 @@ func envFromFiles() []string {
 
 		envLines := strings.Split(string(b), "\n")
 		for _, env := range envLines {
-			if strings.HasPrefix(env, "export ") {
-				env = strings.Split(env, "export ")[1]
-			}
-			envs = append(envs, env)
+			envs = append(envs, strings.TrimPrefix(env, "export "))
 		}
 	}
 


### PR DESCRIPTION
In #28 I forgot to push a commit that makes `env` files `export` compatible :disappointed:.

So this PR adds support for `env` files like this:
```property
MY_ENV=value
```
and this as well:
```property
export MY_ENV=value
```